### PR TITLE
Add .editorconfig to prevent different formatting styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 2
+tab_width = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+
+[*.{go,mod,sum}]
+indent_size = 2
+tab_width = 2
+indent_style = tab


### PR DESCRIPTION
To ensure a cleaner codebase it would be great to have this editorconfig in place so files are concistently formatted and outlined.