### PR TITLE
Remove unnecessary if statement from workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,8 +65,6 @@ jobs:
     needs: [build]
     runs-on: ubuntu-20.04
 
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2.1.3


### PR DESCRIPTION
Since adding the pull request types, we don't
run duplicate workflows anymore on push and pr.