### PR TITLE
Add additional labels to Docker images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,8 +46,10 @@ dockers:
       - "--pull"
       - "--label=com.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.description={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.licenses=MIT"
     extra_files:
       - "Makefile"
       - "go.mod"


### PR DESCRIPTION
See https://github.com/philips-labs/spiffe-vault/pkgs/container/spiffe-vault/9566269?tag=v0.2.2 for the result

It fills in the `About this version` section with this projects name and also adds the license information.