### PR TITLE
Remove emojis and add commit sign-off

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,22 +12,7 @@ The following is a set of guidelines for contributing to SLSA-provenance-action,
 - Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
 - Limit the first line to 72 characters or less
 - Reference issues and pull requests liberally after the first line
-- Consider starting the commit message with an applicable emoji:
-  - :art: `:art:` when improving the format/structure of the code
-  - :racehorse: `:racehorse:` when improving performance
-  - :non-potable_water: `:non-potable_water:` when plugging memory leaks
-  - :memo: `:memo:` when writing docs
-  - :penguin: `:penguin:` when fixing something on Linux
-  - :apple: `:apple:` when fixing something on macOS
-  - :checkered_flag: `:checkered_flag:` when fixing something on Windows
-  - :bug: `:bug:` when fixing a bug
-  - :fire: `:fire:` when removing code or files
-  - :green_heart: `:green_heart:` when fixing the CI build
-  - :white_check_mark: `:white_check_mark:` when adding tests
-  - :lock: `:lock:` when dealing with security
-  - :arrow_up: `:arrow_up:` when upgrading dependencies
-  - :arrow_down: `:arrow_down:` when downgrading dependencies
-  - :shirt: `:shirt:` when removing linter warnings
+- Sign-off your commits with ``git commit -s -m "Normal Commit Message here"``, this will add ``Signed-off-by: Random J Developer <random@developer.example.org>`` at the end of the commit.
 
 ### Code
 


### PR DESCRIPTION
- Update contribution guidelines to mention commit sign-off.
- Removed the emojis as recommendations for commit messages, they are difficult to use as you need to reference the contributing.md every time you make a commit... In my opinion, they also look ugly 😊