### PR TITLE
Don't require GITHUB_TOKEN for non-downloads

### DIFF
--- a/cmd/slsa-provenance/cli/generate_test.go
+++ b/cmd/slsa-provenance/cli/generate_test.go
@@ -436,6 +436,10 @@ func TestGenerateCliOptions(t *testing.T) {
 }
 
 func TestProvenenaceGitHubRelease(t *testing.T) {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		t.Skip("skipping as GITHUB_TOKEN environment variable isn't set")
+	}
 	assert := assert.New(t)
 
 	_, filename, _, _ := runtime.Caller(0)
@@ -445,7 +449,7 @@ func TestProvenenaceGitHubRelease(t *testing.T) {
 
 	ctx := context.Background()
 	owner, repo := "philips-labs", "slsa-provenance-action"
-	oauthClient := github.NewOAuth2Client(ctx, func() string { return os.Getenv("GITHUB_TOKEN") })
+	oauthClient := github.NewOAuth2Client(ctx, func() string { return githubToken })
 	client := github.NewReleaseClient(oauthClient)
 
 	releaseID, err := createGitHubRelease(

--- a/lib/github/provenance_test.go
+++ b/lib/github/provenance_test.go
@@ -280,6 +280,9 @@ func TestGenerateProvenance(t *testing.T) {
 }
 
 func TestGenerateProvenanceFromGitHubRelease(t *testing.T) {
+	if tokenRetriever() == "" {
+		t.Skip("skipping as GITHUB_TOKEN environment variable isn't set")
+	}
 	assert := assert.New(t)
 
 	ctx := context.Background()

--- a/lib/github/releases_test.go
+++ b/lib/github/releases_test.go
@@ -52,6 +52,9 @@ func TestFetchRelease(t *testing.T) {
 }
 
 func TestDownloadReleaseAssets(t *testing.T) {
+	if tokenRetriever() == "" {
+		t.Skip("skipping as GITHUB_TOKEN environment variable isn't set")
+	}
 	assert := assert.New(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
This allows users to sign whatever comes out of the build, instead of
contacting GH to get data or download artifacts.

Signed-off-by: Pieter Lexis <pieter.lexis@powerdns.com>