### PR TITLE
Change default to provenance.json instead of build.provenance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,7 +122,7 @@ jobs:
         uses: philips-labs/slsa-provenance-action@v0.4.0
         with:
           artifact_path: release-assets
-          output_path: 'build.provenance'
+          output_path: 'provenance.json'
           tag_name: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/example-local.yaml
+++ b/.github/workflows/example-local.yaml
@@ -63,4 +63,4 @@ jobs:
       - name: Upload provenance
         uses: actions/upload-artifact@v2
         with:
-          path: build.provenance
+          path: provenance.json

--- a/.github/workflows/example-publish.yaml
+++ b/.github/workflows/example-publish.yaml
@@ -33,4 +33,4 @@ jobs:
       - name: Upload provenance
         uses: actions/upload-artifact@v2
         with:
-          path: build.provenance
+          path: provenance.json

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The easiest way to use this action is to add the following into your workflow fi
         uses: philips-labs/slsa-provenance-action@v0.4.0
         with:
           artifact_path: release-assets
-          output_path: 'build.provenance'
+          output_path: 'provenance.json'
           tag_name: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -188,7 +188,7 @@ The easiest way to use this action is to add the following into your workflow fi
       - name: Upload provenance
         uses: actions/upload-artifact@v2
         with:
-          path: build.provenance
+          path: provenance.json
   ```
 
 </details>
@@ -206,7 +206,7 @@ An action to generate SLSA build provenance for an artifact
 | parameter | description | required | default |
 | - | - | - | - |
 | artifact_path | path to artifact or directory of artifacts | `true` |  |
-| output_path | path to write build provenance file | `true` | build.provenance |
+| output_path | path to write build provenance file | `true` | provenance.json |
 | github_context | internal (do not set): the "github" context object in json | `true` | ${{ toJSON(github) }} |
 | runner_context | internal (do not set): the "runner" context object in json | `true` | ${{ toJSON(runner) }} |
 | tag_name | The github release to generate provenance on.

--- a/action.yaml
+++ b/action.yaml
@@ -10,7 +10,7 @@ inputs:
   output_path:
     description: 'path to write build provenance file'
     required: true
-    default: 'build.provenance'
+    default: 'provenance.json'
   github_context:
     description: 'internal (do not set): the "github" context object in json'
     required: true

--- a/cmd/slsa-provenance/cli/generate.go
+++ b/cmd/slsa-provenance/cli/generate.go
@@ -29,7 +29,7 @@ func Generate(w io.Writer) *ffcli.Command {
 		tagName = flagset.String("tag_name", "", `The github release to generate provenance on.
 (if set the artifacts will be downloaded from the release and the provenance will be added as an additional release asset.)`)
 		artifactPath   = flagset.String("artifact_path", "", "The file or dir path of the artifacts for which provenance should be generated.")
-		outputPath     = flagset.String("output_path", "build.provenance", "The path to which the generated provenance should be written.")
+		outputPath     = flagset.String("output_path", "provenance.json", "The path to which the generated provenance should be written.")
 		githubContext  = flagset.String("github_context", "", "The '${github}' context value.")
 		runnerContext  = flagset.String("runner_context", "", "The '${runner}' context value.")
 		extraMaterials = []string{}

--- a/lib/github/provenance_test.go
+++ b/lib/github/provenance_test.go
@@ -357,7 +357,7 @@ func TestGenerateProvenanceFromGitHubRelease(t *testing.T) {
 	assertMetadata(assert, predicate.Metadata, ghContext, repoURL)
 	assertInvocation(assert, predicate.Invocation)
 
-	stmtPath := path.Join(artifactPath, "build.provenance")
+	stmtPath := path.Join(artifactPath, "provenance.json")
 
 	err = env.PersistProvenanceStatement(ctx, stmt, stmtPath)
 	assert.NoError(err)


### PR DESCRIPTION
## Problem with `.provenance` filename

Default filename currently is `build.provenance` which is annoying because no editor has a file type associated with `.provenance`.

## Proposed change

Change default name to `provenance.json` since it is a json file describing the provenance. Now all IDEs recognise the file format.

