### PR TITLE
Fix release provenance to use the new github-release subcommand

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,6 +121,7 @@ jobs:
       - name: Generate provenance for Release
         uses: philips-labs/slsa-provenance-action@v0.4.0
         with:
+          sub-command: github-release
           artifact_path: release-assets
           output_path: 'provenance.json'
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
We forgot to update the workflow to use the new github-release subcommand in this PR. #98 

Would also like to cut out a new release before we merge the new features after this.