### PR TITLE
Signing of artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,7 +183,6 @@ jobs:
 
       - name: Verify attestation
         run: |
-          echo '${{ secrets.COSIGN_PUBLIC_KEY }}' > cosign.pub
           cosign verify-attestation --key cosign.pub ${{ matrix.repo }}@${{ needs.release.outputs.container_digest }}
 
       - name: Logout from Container registries

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,7 +156,7 @@ jobs:
           cosign-release: 'v1.4.1'
 
       - name: Generate provenance for ${{ matrix.repo }}
-        uses: philips-labs/slsa-provenance-action@v0.5.0
+        uses: philips-labs/slsa-provenance-action@v0.5.1-draft
         with:
           command: generate
           subcommand: container
@@ -201,7 +201,7 @@ jobs:
 
     steps:
       - name: Generate provenance for Release
-        uses: philips-labs/slsa-provenance-action@v0.5.0
+        uses: philips-labs/slsa-provenance-action@v0.5.1-draft
         with:
           command: generate
           subcommand: github-release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,11 @@ jobs:
         with:
           go-version: 1.17
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v1.4.1
+        with:
+          cosign-release: 'v1.4.1'
+
       - name: Checkout
         uses: actions/checkout@v2.4.0
         with:
@@ -100,6 +105,10 @@ jobs:
           fi
           rm -f /tmp/spiffe-vault-release-vars.env
 
+      - name: Install signing key
+        run: |
+          echo '${{ secrets.COSIGN_PRIVATE_KEY }}' > cosign.key
+
       - name: Release ${{ (!startsWith(github.ref, 'refs/tags/') && 'snapshot') || '' }}
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -109,6 +118,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           LDFLAGS: ${{ steps.release-vars.outputs.LDFLAGS }}
           GIT_HASH: ${{ steps.release-vars.outputs.GIT_HASH }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
 
       - name: Get container info
         id: container_info
@@ -124,6 +134,10 @@ jobs:
         run: |
           docker logout
           docker logout ghcr.io
+
+      - name: Cleanup signing keys
+        if: ${{ always() }}
+        run: rm -f cosign.key
 
   container-provenance:
     name: container-provenance
@@ -177,6 +191,7 @@ jobs:
         run: |
           docker logout
           docker logout ghcr.io
+          rm -f cosign.key
 
   provenance:
     name: provenance

--- a/.github/workflows/example-publish.yaml
+++ b/.github/workflows/example-publish.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/download-artifact@v2
 
       - name: Generate provenance
-        uses: philips-labs/slsa-provenance-action@v0.5.0
+        uses: philips-labs/slsa-provenance-action@v0.5.1-draft
         with:
           command: generate
           subcommand: files

--- a/.goreleaser.draft.yml
+++ b/.goreleaser.draft.yml
@@ -30,9 +30,14 @@ archives:
     files:
       - LICENSE*
       - README*
+      - cosign.pub
+      - dist/*.sig
     format_overrides:
       - goos: windows
         format: zip
+
+checksum:
+  name_template: 'checksums.txt'
 
 dockers:
   - goos: linux
@@ -57,8 +62,57 @@ dockers:
       - "go.sum"
       - "cmd"
       - "lib"
-checksum:
-  name_template: 'checksums.txt'
+
+signs:
+  - id: checksums
+    cmd: cosign
+    stdin: '{{ .Env.COSIGN_PASSWORD }}'
+    certificate: '${artifact}.pem'
+    output: true
+    artifacts: checksum
+    args:
+      - sign-blob
+      - --key
+      - cosign.key
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
+  - id: binaries
+    cmd: cosign
+    stdin: '{{ .Env.COSIGN_PASSWORD }}'
+    certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
+    output: true
+    artifacts: binary
+    args:
+      - sign-blob
+      - --key
+      - cosign.key
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
+  - id: archives
+    cmd: cosign
+    stdin: '{{ .Env.COSIGN_PASSWORD }}'
+    certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
+    output: true
+    artifacts: archive
+    args:
+      - sign-blob
+      - --key
+      - cosign.key
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
+
+docker_signs:
+  - cmd: cosign
+    artifacts: manifests
+    output: true
+    args:
+      - 'sign'
+      - --key
+      - cosign.key
+      - '${artifact}'
 
 snapshot:
   name_template: "{{ .Version }}-next"
@@ -75,3 +129,5 @@ changelog:
 release:
   draft: true
   prerelease: auto
+  extra_files:
+    - glob: "./cosign.pub"

--- a/.goreleaser.draft.yml
+++ b/.goreleaser.draft.yml
@@ -67,7 +67,6 @@ signs:
   - id: checksums
     cmd: cosign
     stdin: '{{ .Env.COSIGN_PASSWORD }}'
-    # certificate: '${artifact}.pem'
     output: true
     artifacts: checksum
     args:
@@ -80,7 +79,6 @@ signs:
   - id: binaries
     cmd: cosign
     stdin: '{{ .Env.COSIGN_PASSWORD }}'
-    # certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
     output: true
     artifacts: binary
     args:
@@ -93,7 +91,6 @@ signs:
   - id: archives
     cmd: cosign
     stdin: '{{ .Env.COSIGN_PASSWORD }}'
-    # certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
     output: true
     artifacts: archive
     args:

--- a/.goreleaser.draft.yml
+++ b/.goreleaser.draft.yml
@@ -67,7 +67,7 @@ signs:
   - id: checksums
     cmd: cosign
     stdin: '{{ .Env.COSIGN_PASSWORD }}'
-    certificate: '${artifact}.pem'
+    # certificate: '${artifact}.pem'
     output: true
     artifacts: checksum
     args:
@@ -80,7 +80,7 @@ signs:
   - id: binaries
     cmd: cosign
     stdin: '{{ .Env.COSIGN_PASSWORD }}'
-    certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
+    # certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
     output: true
     artifacts: binary
     args:
@@ -93,7 +93,7 @@ signs:
   - id: archives
     cmd: cosign
     stdin: '{{ .Env.COSIGN_PASSWORD }}'
-    certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
+    # certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
     output: true
     artifacts: archive
     args:

--- a/.goreleaser.draft.yml
+++ b/.goreleaser.draft.yml
@@ -106,7 +106,7 @@ signs:
 
 docker_signs:
   - cmd: cosign
-    artifacts: manifests
+    artifacts: all
     output: true
     args:
       - 'sign'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,7 +67,6 @@ signs:
   - id: checksums
     cmd: cosign
     stdin: '{{ .Env.COSIGN_PASSWORD }}'
-    certificate: '${artifact}.pem'
     output: true
     artifacts: checksum
     args:
@@ -80,7 +79,6 @@ signs:
   - id: binaries
     cmd: cosign
     stdin: '{{ .Env.COSIGN_PASSWORD }}'
-    certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
     output: true
     artifacts: binary
     args:
@@ -93,7 +91,6 @@ signs:
   - id: archives
     cmd: cosign
     stdin: '{{ .Env.COSIGN_PASSWORD }}'
-    certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
     output: true
     artifacts: archive
     args:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,9 +30,14 @@ archives:
     files:
       - LICENSE*
       - README*
+      - cosign.pub
+      - dist/*.sig
     format_overrides:
       - goos: windows
         format: zip
+
+checksum:
+  name_template: 'checksums.txt'
 
 dockers:
   - goos: linux
@@ -57,8 +62,44 @@ dockers:
       - "go.sum"
       - "cmd"
       - "lib"
-checksum:
-  name_template: 'checksums.txt'
+
+signs:
+  - id: checksums
+    cmd: cosign
+    stdin: '{{ .Env.COSIGN_PASSWORD }}'
+    certificate: '${artifact}.pem'
+    output: true
+    artifacts: checksum
+    args:
+      - sign-blob
+      - --key
+      - cosign.key
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
+  - id: archives
+    cmd: cosign
+    stdin: '{{ .Env.COSIGN_PASSWORD }}'
+    certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
+    output: true
+    artifacts: archive
+    args:
+      - sign-blob
+      - --key
+      - cosign.key
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
+
+docker_signs:
+  - cmd: cosign
+    artifacts: manifests
+    output: true
+    args:
+      - 'sign'
+      - --key
+      - cosign.key
+      - '${artifact}'
 
 snapshot:
   name_template: "{{ .Version }}-next"
@@ -75,3 +116,5 @@ changelog:
 release:
   draft: false
   prerelease: auto
+  extra_files:
+    - glob: "./cosign.pub"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -106,7 +106,7 @@ signs:
 
 docker_signs:
   - cmd: cosign
-    artifacts: manifests
+    artifacts: all
     output: true
     args:
       - 'sign'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,6 +77,19 @@ signs:
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'
+  - id: binaries
+    cmd: cosign
+    stdin: '{{ .Env.COSIGN_PASSWORD }}'
+    certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
+    output: true
+    artifacts: binary
+    args:
+      - sign-blob
+      - --key
+      - cosign.key
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
   - id: archives
     cmd: cosign
     stdin: '{{ .Env.COSIGN_PASSWORD }}'

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ image: ## build the binary in a docker image
 		.
 
 $(GO_PATH)/bin/goreleaser:
-	go install github.com/goreleaser/goreleaser@v0.182.1
+	go install github.com/goreleaser/goreleaser@v1.2.5
 
 .PHONY: snapshot-release
 snapshot-release: $(GO_PATH)/bin/goreleaser ## creates a snapshot release using goreleaser

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ See all available images [here.](https://hub.docker.com/r/philipssoftware/slsa-p
 Run the Docker image by doing:
 
 ```sh
-docker run philipssoftware/slsa-provenance:v0.5.0
+docker run philipssoftware/slsa-provenance:v0.5.1-draft
 ```
 
 **GitHub Container Registry**
@@ -117,7 +117,7 @@ See all available images [here.](https://github.com/philips-labs/slsa-provenance
 Run the Docker image by doing:
 
 ```sh
-docker run ghcr.io/philips-labs/slsa-provenance:v0.5.0
+docker run ghcr.io/philips-labs/slsa-provenance:v0.5.1-draft
 ```
 
 The Docker image includes the working binary that can be executed by using the ``slsa-provenance`` command.
@@ -145,7 +145,7 @@ The easiest way to use this action is to add the following into your workflow fi
 
     steps:
       - name: Generate provenance for Release
-        uses: philips-labs/slsa-provenance-action@v0.5.0
+        uses: philips-labs/slsa-provenance-action@v0.5.1-draft
         with:
           command: generate
           subcommand: files
@@ -180,7 +180,7 @@ The easiest way to use this action is to add the following into your workflow fi
           path: extra-materials/
 
       - name: Generate provenance
-        uses: philips-labs/slsa-provenance-action@v0.5.0
+        uses: philips-labs/slsa-provenance-action@v0.5.1-draft
         with:
           command: generate
           subcommand: files

--- a/action.yaml
+++ b/action.yaml
@@ -47,6 +47,6 @@ runs:
       run: |
         echo Running slsa-provenance with following arguments
         echo ${{ steps.compose-args.outputs.provenance_args }}
-    - uses: 'docker://ghcr.io/philips-labs/slsa-provenance:v0.5.0'
+    - uses: 'docker://ghcr.io/philips-labs/slsa-provenance:v0.5.1-draft'
       with:
         args: ${{ steps.compose-args.outputs.provenance_args }}

--- a/release.md
+++ b/release.md
@@ -5,7 +5,7 @@
 To make a new release you can make use of the following `make` task.
 
 ```bash
-make gh-release NEW_VERSION=v0.6.0 OLD_VERSION=v0.5.0 DESCRIPTION="A test release to see how it works"
+make gh-release NEW_VERSION=v0.6.0 OLD_VERSION=v0.5.1-draft DESCRIPTION="A test release to see how it works"
 ```
 
 `NEW_VERSION` the version that you want to release.


### PR DESCRIPTION
resolves #106

See https://github.com/philips-labs/slsa-provenance-action/releases/tag/untagged-d09d505c32891e407fd4 for the artifacts

Docker images can be verified like this.

```bash
$ docker pull philipssoftware/slsa-provenance:v0.5.1-draft
$ docker pull ghcr.io/philips-labs/slsa-provenance:v0.5.1-draft
$ cosign verify --key philipssoftware/slsa-provenance:v0.5.1-draft

Verification for index.docker.io/philipssoftware/slsa-provenance:v0.5.1-draft --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - The signatures were verified against the specified public key
  - Any certificates were verified against the Fulcio roots.

[{"critical":{"identity":{"docker-reference":"index.docker.io/philipssoftware/slsa-provenance"},"image":{"docker-manifest-digest":"sha256:db2e390821a87cb5e0ee628d674b559d639f08b1e665510a65a500f630730d04"},"type":"cosign container image signature"},"optional":null}]
$ cosign verify --key cosign.pub ghcr.io/philips-labs/slsa-provenance:v0.5.1-draft

Verification for ghcr.io/philips-labs/slsa-provenance:v0.5.1-draft --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - The signatures were verified against the specified public key
  - Any certificates were verified against the Fulcio roots.

[{"critical":{"identity":{"docker-reference":"ghcr.io/philips-labs/slsa-provenance"},"image":{"docker-manifest-digest":"sha256:db2e390821a87cb5e0ee628d674b559d639f08b1e665510a65a500f630730d04"},"type":"cosign container image signature"},"optional":null}]
```