### PR TITLE
Checkout for public key that is required for attesting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,6 +150,9 @@ jobs:
         repo: ${{ fromJSON(needs.release.outputs.container_repos) }}
 
     steps:
+      - name: Checkout for public key
+        uses: actions/checkout@v2.4.0
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v1.4.1
         with:


### PR DESCRIPTION
Signed-off-by: Brend Smits <brend.smits@philips.com>

Was failing here: https://github.com/philips-labs/slsa-provenance-action/runs/4818393733?check_suite_focus=true#step:8:5
Likely due to not being able to find the key.