### PR TITLE
Fix list releases test

### DIFF
--- a/lib/github/releases_test.go
+++ b/lib/github/releases_test.go
@@ -195,13 +195,13 @@ func TestListReleases(t *testing.T) {
 	api := "https://api.github.com/repos/philips-labs/slsa-provenance-action/releases"
 
 	client, requestLogger := createReleaseClient(ctx)
-	opt := gh.ListOptions{PerPage: 5}
+	opt := gh.ListOptions{PerPage: 10}
 	releases, err := client.ListReleases(ctx, owner, repo, opt)
 	if !assert.NoError(err) {
 		return
 	}
 	assert.NotEmpty(requestLogger)
-	assert.Equal(expectedRequestPages("GET", api, opt.PerPage, 3), requestLogger.String())
+	assert.Equal(expectedRequestPages("GET", api, opt.PerPage, 2), requestLogger.String())
 	assert.GreaterOrEqual(len(releases), 2)
 
 	opt = gh.ListOptions{PerPage: 2}


### PR DESCRIPTION
This resolves the test for the upcoming 3 releases.

Currently we have 18 releases (including 1 draft).

Once we hit 21 releases we have to increment page-count again.