### PR TITLE
feat(cli): context by environment

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,44 @@
+name: Integration Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke-tests:
+    permissions:
+      contents: read
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Create artifacts
+        run:  |
+          mkdir artifacts
+          echo "onion, tomato, jalapeno, cilantro, lime, salt" > artifacts/salsa.txt
+          echo "audi, tesla, bmw" > artifacts/cars.txt
+      -
+        name: Generate some extra materials (this usually happens as part of the build process)
+        run: |
+          echo '[{"uri": "pkg:deb/debian/stunnel4@5.50-3?arch=amd64", "digest": {"sha256": "e1731ae217fcbc64d4c00d707dcead45c828c5f762bcf8cc56d87de511e096fa"}}]' > artifacts/extra-materials.json
+      -
+        name: Install cosign
+        uses: sigstore/cosign-installer@v2.0.0
+        with:
+          cosign-release: 'v1.5.1'
+      -
+        name: Generate provenance from artifacts
+        uses: phillips/slsa-provenance-action@v0.7.2
+        with:
+          command: generate
+          subcommand: files
+          arguments: --artifact-path artifacts --extra-materials artifacts/extra-materials.json --output-path provenance.json
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,26 +13,21 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
-      -
-        name: Create artifacts
+      - name: Create artifacts
         run:  |
           mkdir artifacts
           echo "onion, tomato, jalapeno, cilantro, lime, salt" > artifacts/salsa.txt
           echo "audi, tesla, bmw" > artifacts/cars.txt
-      -
-        name: Generate some extra materials (this usually happens as part of the build process)
+      - name: Generate some extra materials (this usually happens as part of the build process)
         run: |
           echo '[{"uri": "pkg:deb/debian/stunnel4@5.50-3?arch=amd64", "digest": {"sha256": "e1731ae217fcbc64d4c00d707dcead45c828c5f762bcf8cc56d87de511e096fa"}}]' > artifacts/extra-materials.json
-      -
-        name: Install cosign
+      - name: Install cosign
         uses: sigstore/cosign-installer@v2.0.0
         with:
           cosign-release: 'v1.5.1'
-      -
-        name: Generate provenance from artifacts
+      - name: Generate provenance from artifacts
         uses: phillips/slsa-provenance-action@v0.7.2
         with:
           command: generate

--- a/action.yaml
+++ b/action.yaml
@@ -40,15 +40,8 @@ runs:
       id: compose-args
       shell: bash
       run: |
-        encoded_github="$(echo ${GITHUB_CONTEXT} | base64 -w 0)"
-        encoded_runner="$(echo ${RUNNER_CONTEXT} | base64 -w 0)"
-
         args=(${{ inputs.command }})
         args+=(${{ inputs.subcommand }})
-        args+=(--github-context)
-        args+=("${encoded_github}")
-        args+=(--runner-context)
-        args+=("${encoded_runner}")
         args+=(${{ inputs.arguments }})
 
         echo "::set-output name=provenance_args::${args[@]}"

--- a/cmd/slsa-provenance/cli/commands.go
+++ b/cmd/slsa-provenance/cli/commands.go
@@ -21,6 +21,12 @@ func RequiredFlagError(flagName string) error {
 	return fmt.Errorf("no value found for required flag: %s", flagName)
 }
 
+// RequiredEnvironmentVariableError creates a required environment variable
+// error for the given environment variable name
+func RequiredEnvironmentVariableError(envName string) error {
+	return fmt.Errorf("no value found for required environment variable: %s", envName)
+}
+
 // New creates a new instance of the slsa-provenance commandline interface
 func New() *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/slsa-provenance/cli/container.go
+++ b/cmd/slsa-provenance/cli/container.go
@@ -18,17 +18,17 @@ func OCI() *cobra.Command {
 		Use:   "container",
 		Short: "Generate provenance on container assets",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			outputPath, err := o.GetOutputPath()
-			if err != nil {
-				return err
-			}
-
 			gh, err := o.GetGitHubContext()
 			if err != nil {
 				return err
 			}
 
 			runner, err := o.GetRunnerContext()
+			if err != nil {
+				return err
+			}
+
+			outputPath, err := o.GetOutputPath()
 			if err != nil {
 				return err
 			}

--- a/cmd/slsa-provenance/cli/container_test.go
+++ b/cmd/slsa-provenance/cli/container_test.go
@@ -1,7 +1,7 @@
 package cli_test
 
 import (
-	"encoding/base64"
+	"fmt"
 	"os"
 	"path"
 	"runtime"
@@ -14,73 +14,150 @@ import (
 
 func TestGenerateContainerCliOptions(t *testing.T) {
 	_, filename, _, _ := runtime.Caller(0)
+	rootDir := path.Join(path.Dir(filename), "../../..")
 	provenanceFile := path.Join(path.Dir(filename), "provenance.json")
 
-	base64GitHubContext := base64.StdEncoding.EncodeToString([]byte(githubContext))
-	base64RunnerContext := base64.StdEncoding.EncodeToString([]byte(runnerContext))
-
 	testCases := []struct {
-		name      string
-		err       error
-		arguments []string
+		name        string
+		err         error
+		arguments   []string
+		environment map[string]string
 	}{
 		{
-			name:      "without commandline flags",
-			err:       cli.RequiredFlagError("github-context"),
-			arguments: make([]string, 0),
+			name:        "no environment variables",
+			err:         cli.RequiredEnvironmentVariableError("GITHUB_CONTEXT"),
+			arguments:   []string{},
+			environment: map[string]string{},
 		},
 		{
-			name: "only github-context given",
-			err:  cli.RequiredFlagError("runner-context"),
-			arguments: []string{
-				"--github-context",
-				base64GitHubContext,
+			name:      "only github-context given",
+			err:       cli.RequiredEnvironmentVariableError("RUNNER_CONTEXT"),
+			arguments: []string{},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
 			},
 		},
 		{
-			name: "only context flags given",
+			name:      "only contexts given",
+			err:       cli.RequiredFlagError("repository"),
+			arguments: []string{},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
+			},
+		},
+		{
+			name: "invalid --output-path",
+			err:  fmt.Errorf("no value found for required flag: output-path"),
+			arguments: []string{
+				"--output-path",
+				"",
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
+			},
+		},
+		{
+			name: "With extra materials",
 			err:  cli.RequiredFlagError("repository"),
 			arguments: []string{
-				"--github-context",
-				base64GitHubContext,
-				"--runner-context",
-				base64RunnerContext,
+				"--output-path",
+				provenanceFile,
+				"--extra-materials",
+				path.Join(rootDir, "test-data/materials-valid.json"),
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
+			},
+		},
+		{
+			name: "With broken extra materials",
+			err:  fmt.Errorf("failed retrieving extra materials for %s: unexpected EOF", path.Join(rootDir, "test-data/materials-broken.not-json")),
+			arguments: []string{
+				"--output-path",
+				provenanceFile,
+				"--extra-materials",
+				path.Join(rootDir, "test-data/materials-broken.not-json"),
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
+			},
+		},
+		{
+			name: "With non-existent extra materials",
+			err:  fmt.Errorf("failed retrieving extra materials: open %s: no such file or directory", unknownFile),
+			arguments: []string{
+				"--output-path",
+				provenanceFile,
+				"--extra-materials",
+				fmt.Sprintf("%s,%s", path.Join(rootDir, "test-data/materials-valid.json"), unknownFile),
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
+			},
+		},
+		{
+			name: "With broken extra materials (no uri)",
+			err:  fmt.Errorf("failed retrieving extra materials for %s: empty or missing \"uri\" for material", path.Join(rootDir, "test-data/materials-no-uri.json")),
+			arguments: []string{
+				"--output-path",
+				provenanceFile,
+				"--extra-materials",
+				path.Join(rootDir, "test-data/materials-no-uri.json"),
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
+			},
+		},
+		{
+			name: "With broken extra materials (no digest)",
+			err:  fmt.Errorf("failed retrieving extra materials for %s: empty or missing \"digest\" for material", path.Join(rootDir, "test-data/materials-no-digest.json")),
+			arguments: []string{
+				"--output-path",
+				provenanceFile,
+				"--extra-materials",
+				path.Join(rootDir, "test-data/materials-no-digest.json"),
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
 			},
 		},
 		{
 			name: "contexts and tags given",
 			err:  cli.RequiredFlagError("repository"),
 			arguments: []string{
-				"--github-context",
-				base64GitHubContext,
-				"--runner-context",
-				base64RunnerContext,
 				"--tags",
 				"v0.4.0,33ba3da2213c83ce02df0f2f6ba925ec79037f9d",
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
 			},
 		},
 		{
 			name: "contexts, repo and tags given",
 			err:  cli.RequiredFlagError("digest"),
 			arguments: []string{
-				"--github-context",
-				base64GitHubContext,
-				"--runner-context",
-				base64RunnerContext,
 				"--repository",
 				"ghcr.io/philips-labs/slsa-provenance",
 				"--tags",
 				"v0.4.0,33ba3da2213c83ce02df0f2f6ba925ec79037f9d",
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
 			},
 		},
 		{
 			name: "all flags given",
 			err:  nil,
 			arguments: []string{
-				"--github-context",
-				base64GitHubContext,
-				"--runner-context",
-				base64RunnerContext,
 				"--repository",
 				"ghcr.io/philips-labs/slsa-provenance",
 				"--tags",
@@ -88,12 +165,22 @@ func TestGenerateContainerCliOptions(t *testing.T) {
 				"--digest",
 				"sha256:194b471a878add368bf02a7935fa099024576c029491bcefaeb87f81efa093a3",
 			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(tt *testing.T) {
 			assert := assert.New(tt)
+
+			// Set environment
+			os.Clearenv()
+			for k, v := range tc.environment {
+				os.Setenv(k, v)
+			}
 
 			output, err := executeCommand(cli.OCI(), tc.arguments...)
 			defer func() {

--- a/cmd/slsa-provenance/cli/files.go
+++ b/cmd/slsa-provenance/cli/files.go
@@ -18,21 +18,21 @@ func Files() *cobra.Command {
 		Use:   "files",
 		Short: "Generate provenance on file assets",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			artifactPath, err := o.GetArtifactPath()
-			if err != nil {
-				return err
-			}
-			outputPath, err := o.GetOutputPath()
-			if err != nil {
-				return err
-			}
-
 			gh, err := o.GetGitHubContext()
 			if err != nil {
 				return err
 			}
 
 			runner, err := o.GetRunnerContext()
+			if err != nil {
+				return err
+			}
+
+			artifactPath, err := o.GetArtifactPath()
+			if err != nil {
+				return err
+			}
+			outputPath, err := o.GetOutputPath()
 			if err != nil {
 				return err
 			}

--- a/cmd/slsa-provenance/cli/files_test.go
+++ b/cmd/slsa-provenance/cli/files_test.go
@@ -1,7 +1,6 @@
 package cli_test
 
 import (
-	"encoding/base64"
 	"fmt"
 	"os"
 	"path"
@@ -22,37 +21,33 @@ func TestGenerateFilesCliOptions(t *testing.T) {
 	rootDir := path.Join(path.Dir(filename), "../../..")
 	provenanceFile := path.Join(rootDir, "bin/unittest-provenance.json")
 
-	base64GitHubContext := base64.StdEncoding.EncodeToString([]byte(githubContext))
-	base64RunnerContext := base64.StdEncoding.EncodeToString([]byte(runnerContext))
-
 	testCases := []struct {
-		name      string
-		err       error
-		arguments []string
+		name        string
+		err         error
+		arguments   []string
+		environment map[string]string
 	}{
 		{
-			name:      "without commandline flags",
-			err:       cli.RequiredFlagError("artifact-path"),
-			arguments: make([]string, 0),
+			name:        "no environment variables",
+			err:         cli.RequiredEnvironmentVariableError("GITHUB_CONTEXT"),
+			arguments:   []string{},
+			environment: map[string]string{},
 		},
 		{
-			name: "only providing --artifact-path",
-			err:  cli.RequiredFlagError("github-context"),
-			arguments: []string{
-				"--artifact-path",
-				path.Join(rootDir, "bin/slsa-provenance"),
+			name:      "only github-context given",
+			err:       cli.RequiredEnvironmentVariableError("RUNNER_CONTEXT"),
+			arguments: []string{},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
 			},
 		},
 		{
-			name: "without -runner-context",
-			err:  cli.RequiredFlagError("runner-context"),
-			arguments: []string{
-				"--artifact-path",
-				path.Join(rootDir, "bin/slsa-provenance"),
-				"--github-context",
-				base64GitHubContext,
-				"--output-path",
-				provenanceFile,
+			name:      "only contexts given",
+			err:       cli.RequiredFlagError("artifact-path"),
+			arguments: []string{},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
 			},
 		},
 		{
@@ -61,10 +56,24 @@ func TestGenerateFilesCliOptions(t *testing.T) {
 			arguments: []string{
 				"--artifact-path",
 				unknownFile,
-				"--github-context",
-				base64GitHubContext,
-				"--runner-context",
-				base64RunnerContext,
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
+			},
+		},
+		{
+			name: "invalid --output-path",
+			err:  fmt.Errorf("no value found for required flag: output-path"),
+			arguments: []string{
+				"--artifact-path",
+				unknownFile,
+				"--output-path",
+				"",
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
 			},
 		},
 		{
@@ -73,12 +82,12 @@ func TestGenerateFilesCliOptions(t *testing.T) {
 			arguments: []string{
 				"--artifact-path",
 				path.Join(rootDir, "bin/slsa-provenance"),
-				"--github-context",
-				base64GitHubContext,
 				"--output-path",
 				provenanceFile,
-				"--runner-context",
-				base64RunnerContext,
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
 			},
 		},
 		{
@@ -87,14 +96,14 @@ func TestGenerateFilesCliOptions(t *testing.T) {
 			arguments: []string{
 				"--artifact-path",
 				path.Join(rootDir, "bin/slsa-provenance"),
-				"--github-context",
-				base64GitHubContext,
 				"--output-path",
 				provenanceFile,
-				"--runner-context",
-				base64RunnerContext,
 				"--extra-materials",
 				path.Join(rootDir, "test-data/materials-valid.json"),
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
 			},
 		},
 		{
@@ -103,14 +112,14 @@ func TestGenerateFilesCliOptions(t *testing.T) {
 			arguments: []string{
 				"--artifact-path",
 				path.Join(rootDir, "bin/slsa-provenance"),
-				"--github-context",
-				base64GitHubContext,
 				"--output-path",
 				provenanceFile,
-				"--runner-context",
-				base64RunnerContext,
 				"--extra-materials",
 				path.Join(rootDir, "test-data/materials-broken.not-json"),
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
 			},
 		},
 		{
@@ -119,14 +128,14 @@ func TestGenerateFilesCliOptions(t *testing.T) {
 			arguments: []string{
 				"--artifact-path",
 				path.Join(rootDir, "bin/slsa-provenance"),
-				"--github-context",
-				base64GitHubContext,
 				"--output-path",
 				provenanceFile,
-				"--runner-context",
-				base64RunnerContext,
 				"--extra-materials",
 				fmt.Sprintf("%s,%s", path.Join(rootDir, "test-data/materials-valid.json"), unknownFile),
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
 			},
 		},
 		{
@@ -135,14 +144,14 @@ func TestGenerateFilesCliOptions(t *testing.T) {
 			arguments: []string{
 				"--artifact-path",
 				path.Join(rootDir, "bin/slsa-provenance"),
-				"--github-context",
-				base64GitHubContext,
 				"--output-path",
 				provenanceFile,
-				"--runner-context",
-				base64RunnerContext,
 				"--extra-materials",
 				path.Join(rootDir, "test-data/materials-no-uri.json"),
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
 			},
 		},
 		{
@@ -151,14 +160,14 @@ func TestGenerateFilesCliOptions(t *testing.T) {
 			arguments: []string{
 				"--artifact-path",
 				path.Join(rootDir, "bin/slsa-provenance"),
-				"--github-context",
-				base64GitHubContext,
 				"--output-path",
 				provenanceFile,
-				"--runner-context",
-				base64RunnerContext,
 				"--extra-materials",
 				path.Join(rootDir, "test-data/materials-no-digest.json"),
+			},
+			environment: map[string]string{
+				"GITHUB_CONTEXT": githubContext,
+				"RUNNER_CONTEXT": runnerContext,
 			},
 		},
 	}
@@ -166,6 +175,12 @@ func TestGenerateFilesCliOptions(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(tt *testing.T) {
 			assert := assert.New(tt)
+
+			// Set environment
+			os.Clearenv()
+			for k, v := range tc.environment {
+				os.Setenv(k, v)
+			}
 
 			output, err := executeCommand(cli.Files(), tc.arguments...)
 			defer func() {

--- a/cmd/slsa-provenance/cli/github-release.go
+++ b/cmd/slsa-provenance/cli/github-release.go
@@ -21,13 +21,9 @@ func GitHubRelease() *cobra.Command {
 		Use:   "github-release",
 		Short: "Generate provenance on GitHub release assets",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			artifactPath, err := o.GetArtifactPath()
-			if err != nil {
-				return err
-			}
-			outputPath, err := o.GetOutputPath()
-			if err != nil {
-				return err
+			ghToken := os.Getenv("GITHUB_TOKEN")
+			if ghToken == "" {
+				return errors.New("GITHUB_TOKEN environment variable not set")
 			}
 
 			gh, err := o.GetGitHubContext()
@@ -36,6 +32,15 @@ func GitHubRelease() *cobra.Command {
 			}
 
 			runner, err := o.GetRunnerContext()
+			if err != nil {
+				return err
+			}
+
+			artifactPath, err := o.GetArtifactPath()
+			if err != nil {
+				return err
+			}
+			outputPath, err := o.GetOutputPath()
 			if err != nil {
 				return err
 			}
@@ -50,10 +55,6 @@ func GitHubRelease() *cobra.Command {
 				return err
 			}
 
-			ghToken := os.Getenv("GITHUB_TOKEN")
-			if ghToken == "" {
-				return errors.New("GITHUB_TOKEN environment variable not set")
-			}
 			tc := github.NewOAuth2Client(cmd.Context(), func() string { return ghToken })
 			tc.Transport = transport.TeeRoundTripper{
 				RoundTripper: tc.Transport,

--- a/cmd/slsa-provenance/cli/github-release_test.go
+++ b/cmd/slsa-provenance/cli/github-release_test.go
@@ -2,7 +2,6 @@ package cli_test
 
 import (
 	"context"
-	"encoding/base64"
 	"os"
 	"path"
 	"runtime"
@@ -15,7 +14,7 @@ import (
 	"github.com/philips-labs/slsa-provenance-action/pkg/github"
 )
 
-func TestProvenenaceGitHubRelease(t *testing.T) {
+func TestProvenanceGitHubRelease(t *testing.T) {
 	githubToken := os.Getenv("GITHUB_TOKEN")
 	if githubToken == "" {
 		t.Skip("skipping as GITHUB_TOKEN environment variable isn't set")
@@ -48,18 +47,15 @@ func TestProvenenaceGitHubRelease(t *testing.T) {
 		_, err = client.Repositories.DeleteRelease(ctx, owner, repo, releaseID)
 	}()
 
-	base64GitHubContext := base64.StdEncoding.EncodeToString([]byte(githubContext))
-	base64RunnerContext := base64.StdEncoding.EncodeToString([]byte(runnerContext))
+	os.Clearenv()
+	os.Setenv("GITHUB_CONTEXT", githubContext)
+	os.Setenv("RUNNER_CONTEXT", runnerContext)
 
 	output, err := executeCommand(cli.GitHubRelease(),
 		"--artifact-path",
 		artifactPath,
-		"--github-context",
-		base64GitHubContext,
 		"--output-path",
 		provenanceFile,
-		"--runner-context",
-		base64RunnerContext,
 		"--tag-name",
 		"v0.0.0-generate-test",
 	)

--- a/cmd/slsa-provenance/cli/options/files.go
+++ b/cmd/slsa-provenance/cli/options/files.go
@@ -11,6 +11,12 @@ func RequiredFlagError(flagName string) error {
 	return fmt.Errorf("no value found for required flag: %s", flagName)
 }
 
+// RequiredEnvironmentVariableError creates a required environement variable
+// error for the given environment variable name
+func RequiredEnvironmentVariableError(envName string) error {
+	return fmt.Errorf("no value found for required environment variable: %s", envName)
+}
+
 // FilesOptions Commandline flags used for the generate files command.
 type FilesOptions struct {
 	GenerateOptions

--- a/cmd/slsa-provenance/cli/options/generate.go
+++ b/cmd/slsa-provenance/cli/options/generate.go
@@ -22,6 +22,7 @@ type GenerateOptions struct {
 }
 
 const (
+	// ContextLen defines the context content limit.
 	ContextLen = 1024 * 1024 // 1 MB
 )
 

--- a/cmd/slsa-provenance/cli/options/generate.go
+++ b/cmd/slsa-provenance/cli/options/generate.go
@@ -71,7 +71,6 @@ func (o *GenerateOptions) GetRunnerContext() (*github.RunnerContext, error) {
 		return nil, fmt.Errorf("failed to unmarshal runner context json: %w", err)
 	}
 
-	// No error
 	return &runner, nil
 }
 

--- a/install-slsa-provenance.sh
+++ b/install-slsa-provenance.sh
@@ -41,12 +41,12 @@ function download {
 }
 
 func decompress() {
-  case ${1} in
+  case "${1}" in
     *.tar.gz)
-      tar xvf ${1} ${2}
+      tar -xzf "${1}" "${2}"
     ;;
     *.zip)
-      unzip ${1} ${2}
+      unzip "${1}" "${2}"
     ;;
     *)
       log_error "unsupported archive format"

--- a/install-slsa-provenance.sh
+++ b/install-slsa-provenance.sh
@@ -40,6 +40,21 @@ function download {
   echo
 }
 
+func decompress() {
+  case ${1} in
+    *.tar.gz)
+      tar xvf ${1} ${2}
+    ;;
+    *.zip)
+      unzip ${1} ${2}
+    ;;
+    *)
+      log_error "unsupported archive format"
+      exit 1
+    ;;
+  esac
+}
+
 OS=${RUNNER_OS:-Linux}
 ARCH=${RUNNER_ARCH:-X64}
 
@@ -102,7 +117,7 @@ else
 fi
 
 log_info "extracting ${BINARY} from ${ARCHIVE}"
-tar -xzf "${ARCHIVE}" "${BINARY}"
+decompress "${ARCHIVE}" "${BINARY}"
 rm "${ARCHIVE}"
 
 # for testing purposes fall back to "$INSTALL_PATH/GITHUB_PATH"

--- a/pkg/github/provenance.go
+++ b/pkg/github/provenance.go
@@ -59,7 +59,7 @@ func (e *Environment) PersistProvenanceStatement(ctx context.Context, stmt *into
 	if err != nil {
 		return fmt.Errorf("failed to marshal provenance: %w", err)
 	}
-	if err := os.WriteFile(path, payload, 0755); err != nil {
+	if err := os.WriteFile(path, payload, 0644); err != nil {
 		return fmt.Errorf("failed to write provenance: %w", err)
 	}
 


### PR DESCRIPTION
# Context

Consume all contexts (GITHUB_CONTEXT and RUNNER_CONTEXT) via environment variables. The previous strategy was to use a base64 encoded value to pass these contexts via command line. But the `GITHUB_CONTEXT` contains an active Github token value which can be retrieved by decoding the base64 encoded context.

The generated encoded payload is publicly accessible and depending on the permissions allocated to the workflow, this ephemeral token could have high privileges.

By the way, this is very cool project I use in my pro and personal projects, I'm happy to help you to make all of these CI/CD topics more secured as I could help.

# Reference(s)

- https://github.com/philips-labs/slsa-provenance-action/issues/146
- https://cwe.mitre.org/data/definitions/200.html
- https://cwe.mitre.org/data/definitions/522.html