### PR TITLE
Replace workflow name with Actionpath to Entrypoint

### DIFF
--- a/pkg/github/provenance.go
+++ b/pkg/github/provenance.go
@@ -37,7 +37,7 @@ func (e *Environment) GenerateProvenanceStatement(ctx context.Context, subjecter
 		// See https://github.com/github/feedback/discussions/4188
 		intoto.WithInvocation(
 			BuildType,
-			e.Context.Workflow,
+			fmt.Sprintf("%s:%s", e.Context.ActionPath, e.Context.Job),
 			nil,
 			event.Inputs,
 			[]intoto.Item{

--- a/pkg/github/provenance.go
+++ b/pkg/github/provenance.go
@@ -37,7 +37,7 @@ func (e *Environment) GenerateProvenanceStatement(ctx context.Context, subjecter
 		// See https://github.com/github/feedback/discussions/4188
 		intoto.WithInvocation(
 			BuildType,
-			fmt.Sprintf("%s:%s", e.Context.ActionPath, e.Context.Job),
+			e.Context.ActionPath,
 			nil,
 			event.Inputs,
 			[]intoto.Item{

--- a/pkg/github/provenance_test.go
+++ b/pkg/github/provenance_test.go
@@ -241,6 +241,8 @@ func TestGenerateProvenance(t *testing.T) {
 		Repository:      "philips-labs/slsa-provenance-action",
 		Event:           []byte(pushGitHubEvent),
 		EventName:       "push",
+		ActionPath:      ".github/workflows/build.yml",
+		Job:             "job-context",
 		SHA:             "849fb987efc0c0fc72e26a38f63f0c00225132be",
 	}
 	materials := []intoto.Item{
@@ -299,6 +301,8 @@ func TestGenerateProvenanceFromGitHubRelease(t *testing.T) {
 		Repository:      "philips-labs/slsa-provenance-action",
 		Event:           []byte(pushGitHubEvent),
 		EventName:       "push",
+		ActionPath:      ".github/workflows/build.yml",
+		Job:             "job-context",
 		SHA:             "849fb987efc0c0fc72e26a38f63f0c00225132be",
 	}
 	materials := []intoto.Item{
@@ -402,7 +406,7 @@ func TestGenerateProvenanceFromGitHubReleaseErrors(t *testing.T) {
 }
 
 func assertInvocation(assert *assert.Assertions, recipe intoto.Invocation) {
-	assert.Equal("", recipe.ConfigSource.EntryPoint)
+	assert.Equal(".github/workflows/build.yml:job-context", recipe.ConfigSource.EntryPoint)
 	assert.Nil(recipe.Environment)
 	assert.Nil(recipe.Parameters)
 }

--- a/pkg/github/provenance_test.go
+++ b/pkg/github/provenance_test.go
@@ -242,7 +242,6 @@ func TestGenerateProvenance(t *testing.T) {
 		Event:           []byte(pushGitHubEvent),
 		EventName:       "push",
 		ActionPath:      ".github/workflows/build.yml",
-		Job:             "job-context",
 		SHA:             "849fb987efc0c0fc72e26a38f63f0c00225132be",
 	}
 	materials := []intoto.Item{
@@ -302,7 +301,6 @@ func TestGenerateProvenanceFromGitHubRelease(t *testing.T) {
 		Event:           []byte(pushGitHubEvent),
 		EventName:       "push",
 		ActionPath:      ".github/workflows/build.yml",
-		Job:             "job-context",
 		SHA:             "849fb987efc0c0fc72e26a38f63f0c00225132be",
 	}
 	materials := []intoto.Item{
@@ -406,7 +404,7 @@ func TestGenerateProvenanceFromGitHubReleaseErrors(t *testing.T) {
 }
 
 func assertInvocation(assert *assert.Assertions, recipe intoto.Invocation) {
-	assert.Equal(".github/workflows/build.yml:job-context", recipe.ConfigSource.EntryPoint)
+	assert.Equal(".github/workflows/build.yml", recipe.ConfigSource.EntryPoint)
 	assert.Nil(recipe.Environment)
 	assert.Nil(recipe.Parameters)
 }


### PR DESCRIPTION
Add actionPath ~and job~ in Entrypoint

The spec is not very clear on what it should be, but at least the actionpath ~and job~ is unique in a repository. The name can be duplicated.

> **Update**
The job is not needed, since the entire workflow is responsible for the build-artifact. Not only the job (step) which creates the SLSA-Provenance file.

Closes: #226