### PR TITLE
Fix GitHub Releases example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,16 @@ The easiest way to use this action is to add the following into your workflow fi
     name: provenance
     needs: [release]
     runs-on: ubuntu-20.04
+    permissions:
+      # required to update the release.
+      contents: write
 
     steps:
       - name: Generate provenance for Release
         uses: philips-labs/slsa-provenance-action@v0.7.2
         with:
           command: generate
-          subcommand: files
+          subcommand: github-release
           arguments: --artifact-path release-assets --output-path 'provenance.json' --tag-name ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Otherwise:

- subcommand:  you will get:
   Error: unknown flag: --tag-name
- permissions: otherwise 403:
  Error: failed to upload provenance to release: POST https://uploads.github.com/repos/OWNER/REPO/releases/152590477/assets?name=provenance.json: 403 Resource not accessible by integration []

Well, IMO, at least the update in `subcommand` is necessary.